### PR TITLE
Identify Clients with SocketAddr

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -63,7 +63,7 @@ pub(crate) async fn metrics_handler() -> Result<impl Reply, Rejection> {
     Ok(res)
 }
 
-pub fn hash_ip(ip: IpAddr, salt: &str) -> Result<String, argon2::password_hash::Error> {
+pub fn hash_ip(ip: &IpAddr, salt: &str) -> Result<String, argon2::password_hash::Error> {
     use argon2::{
         password_hash::{PasswordHasher, SaltString},
         Argon2,

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,21 +1,21 @@
 use std::collections::HashSet;
-use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::time::SystemTime;
 
 pub struct Session {
     pub sharer: String,
     pub viewers: HashSet<String>,
     pub start_time: SystemTime,
-    pub sharer_ip: IpAddr,
+    pub sharer_socket_addr: SocketAddr,
 }
 
 impl Session {
-    pub fn new(sharer: String, sharer_ip: IpAddr) -> Self {
+    pub fn new(sharer: String, sharer_socket_addr: SocketAddr) -> Self {
         Session {
             sharer,
             viewers: Default::default(),
             start_time: SystemTime::now(),
-            sharer_ip,
+            sharer_socket_addr,
         }
     }
 }


### PR DESCRIPTION
Clients may share the same real IP on different ports. In fact, the semantics of the IP is irrelevant for identification, so long as uniqueness holds.